### PR TITLE
build: remove backend-path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
-backend-path = ["."]
 
 [project]
 name = "spandrel"


### PR DESCRIPTION
## Summary
- drop `backend-path` from build config and ensure wheel is required

## Testing
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_68c71d994e4c83218ed2127ee1c3ed40